### PR TITLE
fix: loadprofile, small packets

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -211,7 +211,7 @@ impl<S: OpenRGBStream> OpenRGB<S> {
             self.protocol,
             0,
             RequestLoadProfile,
-            name.into(),
+            RawString(name.into()),
         ).await
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -64,8 +64,11 @@ pub trait OpenRGBWritableStream: AsyncWriteExt + Sized + Send + Sync + Unpin {
     }
 
     async fn write_packet<I: OpenRGBWritable>(&mut self, protocol: u32, device_id: u32, packet_id: PacketId, data: I) -> Result<(), OpenRGBError> {
-        self.write_header(protocol, device_id, packet_id, data.size(protocol)).await?;
-        self.write_value(data, protocol).await
+        let mut buf: Vec<u8> = Vec::new();
+        buf.write_header(protocol, device_id, packet_id, data.size(protocol)).await?;
+        buf.write_value(data, protocol).await?;
+        self.write(&buf).await?;
+        Ok(())
     }
 }
 
@@ -82,3 +85,5 @@ impl OpenRGBReadableStream for TcpStream {}
 impl OpenRGBWritableStream for TcpStream {}
 
 impl OpenRGBStream for TcpStream {}
+
+impl OpenRGBWritableStream for Vec<u8> {}


### PR DESCRIPTION
The load_profile command was sending a string (u16, then null-terminated), but the spec is that for this command the packet size in the header is the full string length.

This fixed using it locally to load profiles on my machine.

Additionally, I've added a small buffer to writing the packet that makes wireshark debugging simpler. That made it easy to see that an extra two bytes were being sent between the header and the payload.